### PR TITLE
Fix wasm compile statement in blog.

### DIFF
--- a/blog/2021-08-26-futhark-in-the-browser.md
+++ b/blog/2021-08-26-futhark-in-the-browser.md
@@ -54,7 +54,7 @@ for the compiled Futhark program.
 
 For example, a Futhark program `futlib.fut` can be compiled with
 
-    $ futhark wasm futlib.fut
+    $ futhark wasm --lib futlib.fut
 
 which produces the files `futlib.wasm` and `futlib.mjs`.  The latter
 can be imported from JavaScript with:


### PR DESCRIPTION
```
futhark wasm futlib.fut
```
Returns a server executable, instead of a library.


